### PR TITLE
Fixed locale typo, Country -> County

### DIFF
--- a/assets/localities.ts
+++ b/assets/localities.ts
@@ -1512,7 +1512,7 @@ export const localities: LocalityItem[] = [
   },
   {
     county: 'Dublin',
-    locality: 'North Country Dublin',
+    locality: 'North County Dublin',
     geocode: '4013'
   },
   {
@@ -1557,7 +1557,7 @@ export const localities: LocalityItem[] = [
   },
   {
     county: 'Dublin',
-    locality: 'South Country Dublin',
+    locality: 'South County Dublin',
     geocode: '4013'
   },
   {


### PR DESCRIPTION
Fixed spelling typo used when setting geographical location.
