### PR TITLE
Change spelling of Cahirciveen

### DIFF
--- a/assets/localities.ts
+++ b/assets/localities.ts
@@ -1857,7 +1857,7 @@ export const localities: LocalityItem[] = [
   },
   {
     county: 'Kerry',
-    locality: 'Cahirciveen',
+    locality: 'Cahersiveen',
     geocode: '19001'
   },
   {


### PR DESCRIPTION
Change spelling of "Cahirciveen" to locally preferred version "Cahersiveen".