### PR TITLE
Fix typo in spelling from "Inniscrone" to "Enniscrone"

### DIFF
--- a/assets/localities.ts
+++ b/assets/localities.ts
@@ -3832,7 +3832,7 @@ export const localities: LocalityItem[] = [
   },
   {
     county: 'Sligo',
-    locality: 'Inniscrone',
+    locality: 'Enniscrone',
     geocode: '31003'
   },
   {


### PR DESCRIPTION
Fix typo in spelling from "Inniscrone" to "Enniscrone"